### PR TITLE
Save form with HTTP POST (not GET) to save more data

### DIFF
--- a/scripts/io.js
+++ b/scripts/io.js
@@ -85,6 +85,7 @@ var io = {
     $.ajax({
       url:  "code/ajax_save.php",
       data: data_str,
+      type: 'POST',
       success: function(data) {
         var json = $.evalJSON(data);
 


### PR DESCRIPTION
This patch addresses [benkeen/generatedata Issue #2 "Save form with POST ajax"](https://github.com/benkeen/generatedata/issues/2). I couldn't figure out how to link this pull request to it though.
