### PR TITLE
#191 - Japanese Language set to disabled as not fully translated

### DIFF
--- a/resources/lang/ja.php
+++ b/resources/lang/ja.php
@@ -2,7 +2,7 @@
 
 
 $L = array();
-$L["ENABLED"] = true;
+$L["ENABLED"] = false;
 
 // Core language strings
 $L["language"] = "日本語";


### PR DESCRIPTION
Actually only the key strings were translated for Japanese and may still be effectively usable.
