### PR TITLE
Fix Issue #197 - Canada Yukon Territories abbreviation should be "YT"

### DIFF
--- a/plugins/countries/Canada/Canada.class.php
+++ b/plugins/countries/Canada/Canada.class.php
@@ -299,7 +299,7 @@ class Country_Canada extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Yukon",
-			"regionShort" => "YK",
+			"regionShort" => "YT",
 			"regionSlug" => "yukon",
 			"weight" => 1,
 			"cities" => array(


### PR DESCRIPTION
Updated regionShort code to YT.
