### PR TITLE
Fix for issue #230 - Corrects display of accented characters when exporting 'In-Page' as HTML

### DIFF
--- a/resources/scripts/generator.js
+++ b/resources/scripts/generator.js
@@ -986,7 +986,7 @@ define([
 			$("#gdProgressMeter").attr("value", _generateInPageRunningCount);
 
 			// 2. Update the actual content
-			_generateInPageContent += response.content;
+			_generateInPageContent += decodeURIComponent(escape(response.content));
 			_codeMirror.setValue(_generateInPageContent);
 
 			// check the process hasn't been interrupted


### PR DESCRIPTION
Fix for issue #230 - Corrects display of accented characters when exporting 'In-Page' as HTML.
