### PR TITLE
Add country plugin for Sweden

### DIFF
--- a/plugins/countries/Sweden/Sweden.class.php
+++ b/plugins/countries/Sweden/Sweden.class.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @package Countries
+ */
+
+class Country_Sweden extends CountryPlugin {
+	protected $countryName = "Sweden";
+	protected $countrySlug = "sweden";
+	protected $regionNames = "Svenska län";
+	protected $continent = "europe";
+
+	protected $extendedData = array(
+		"zipFormat" => "xxxxx"
+	);
+
+	protected $countryData = array(
+		array(
+			"regionName" => "Gävleborgs län",
+			"regionShort" => "X",
+			"regionSlug" => "gavleborg",
+			"weight" => 1,
+			"cities" => array(
+				"Gävle", "Sandviken", "Hudiksvall", "Bollnäs", "Söderhamn", "Hofors", "Ockelbo"
+			)
+		),
+		array(
+			"regionName" => "Dalarnas län",
+			"regionShort" => "W",
+			"regionSlug" => "dalarna",
+			"weight" => 1,
+			"cities" => array(
+				"Borlänge", "Falun", "Avesta", "Ludvika", "Mora"
+			)
+		),
+		array(
+			"regionName" => "Stockholms län",
+			"regionShort" => "AB",
+			"regionSlug" => "stockholms_lan",
+			"weight" => 5,
+			"cities" => array(
+				"Stockholm", "Södertälje", "Täby", "Tumba", "Upplands Väsby", "Lidingo", "Vallentuna", "Åkersberga",
+				"Märsta", "Boo"
+			)
+		),
+		array(
+			"regionName" => "Västra Götalands län",
+			"regionShort" => "O",
+			"regionSlug" => "vastra_gotaland",
+			"weight" => 4,
+			"cities" => array(
+				"Göteborg", "Borås", "Trollhättan", "Skövde", "Uddevalla", "Lidköping", "Alingsås", "Kungälv",
+				"Vänersborg", "Lerum"
+			)
+		),
+		array(
+			"regionName" => "Östergötlands län",
+			"regionShort" => "E",
+			"regionSlug" => "ostergotland",
+			"weight" => 2,
+			"cities" => array(
+				"Linköping", "Norrköping", "Motala", "Finspång", "Mjölby"
+			)
+		),
+		array(
+			"regionName" => "Jönköpings län",
+			"regionShort" => "F",
+			"regionSlug" => "jonkoping",
+			"weight" => 2,
+			"cities" => array(
+				"Jönköping", "Värnamo", "Nässjö", "Tranås", "Vetlanda"
+			)
+		)
+	);
+
+	public function install() {
+		return CountryPluginHelper::populateDB($this->countryName, $this->countrySlug, $this->countryData);
+	}
+}

--- a/plugins/dataTypes/NamesRegional/NamesRegional.class.php
+++ b/plugins/dataTypes/NamesRegional/NamesRegional.class.php
@@ -267,7 +267,21 @@ class DataType_NamesRegional extends DataTypePlugin {
 				"Palma", "Moreno", "Sanhueza", "Carvajal", "Navarrete", "Sáez", "Alvarado", "Donoso", "Poblete", "Bustamante",
 				"Toro", "Ortega", "Venegas", "Guerrero", "Paredes", "Farías", "San Martín"
 			)
-		)
+		),
+		"sweden" => array(
+			"firstNamesFemale" => array(
+				"Anna", "Maria", "Sofia", "Magdalena", "Sanna", "Sara", "Märta", "Eva", "Camilla",
+				"Catarina", "Elena", "Eleonor", "Lisa", "Emma", "Erica",
+				"Erika", "Silvia"
+			),
+			"firstNamesMale" => array(
+				"Erik", "Anders", "Per", "Pär", "Hans", "Peter", "Petter", "Stefan", "Henrik",
+				"Christian", "Kristian", "Fredrik", "Daniel", "Tomas", "Thomas"
+			),
+			"lastNames" => array(
+				"Andersson", "Ericsson", "Eriksson", "Samuelsson", "Svensson", "Persson", "Staffansson", "Carlsson", "Karlsson", "Bodin"
+			)
+		),
 	);
 	private $generalMaleNames   = array();
 	private $generalFemaleNames = array();


### PR DESCRIPTION
Hi!
I made an attempt to create a country plugin for Sweden. 
The swedish cities are only used when a Region column is used.
It would be nice to use swedish cities even without any region column. I wonder how to add an option "Svenska län" för cities? (see attached image) 

![image](https://cloud.githubusercontent.com/assets/13344874/9003325/53dc5800-376d-11e5-8163-786bb335059b.png)
