### PR TITLE
Chilean Rut DataType

### DIFF
--- a/plugins/dataTypes/Rut/README.md
+++ b/plugins/dataTypes/Rut/README.md
@@ -1,0 +1,26 @@
+## Rut Data Type
+
+This Data Type generates a random Chilean Unique National Role Number
+
+
+### Example API Usage
+
+```javascript
+{
+    "numRows": 20,
+    "rows": [
+        {
+            "type": "Rut",
+            "title": "Rut"
+        }
+    ],
+    "export": {
+        "type": "JSON"
+    }
+}
+```
+ 
+### API help
+
+For more information about the API, check out:
+[http://benkeen.github.io/generatedata/api.html](http://benkeen.github.io/generatedata/api.html)

--- a/plugins/dataTypes/Rut/Rut.class.php
+++ b/plugins/dataTypes/Rut/Rut.class.php
@@ -10,6 +10,7 @@ class DataType_Rut extends DataTypePlugin {
 	protected $dataTypeName = "Rut";
 	protected $dataTypeFieldGroup = "human_data";
 	protected $dataTypeFieldGroupOrder = 105;
+	protected $jsModules = array("Rut.js");
 
 	public function __construct($runtimeContext) {
 		parent::__construct($runtimeContext);
@@ -19,15 +20,68 @@ class DataType_Rut extends DataTypePlugin {
 	}
 	
 	public function generate($generator, $generationContextData) {
-	}
+		$options = $generationContextData["generationOptions"];
+		
+		$rowRutInfo = array();
+		while (list($key, $info) = each($generationContextData["existingRowData"])) {
+			if ($info["dataTypeFolder"] == "Rut") {
+				
+				$rowRutInfo = $info;
+				break;
+			}
+		}
+		reset($generationContextData["existingRowData"]);
+		
+		/*if (!empty($rowRutInfo)) {
+        
+		}
+		else*/ {
+			$rutn = sprintf("%d%03d%03d", mt_rand(5, 50), mt_rand(0,999), mt_rand(0,999));
+            
+			$display = "";
+			
+			if( strpos($options["formatCode"], "xxxxxxxx") !== false )
+			{
+                    if( $options["thousep"] )
+                    {
+                            $display = number_format($rutn, 0, ",", ".");
+                        }
+                    else {
+                        $display = $rutn;
+                    }
+                }
+			if( strpos($options["formatCode"], "xxxxxxxx-y") !== false )
+			{
+				if( !$options["remdash"] )
+				{
+					$display .= "-";
+				}
+			}
+			
+			if( strpos($options["formatCode"], "y") !== false )
+			{
+				if( $options["upper"] )
+				{
+					$display .= strtoupper($this->getDigit($rutn));
+				}
+				else {
+					$display .= $this->getDigit($rutn);
+				}
+			}
+		}
+		
+		return array(
+				"display" => $display
+		);
+    }
 	
 	public function getDataTypeMetadata() {
-		return array(
-				"SQLField" => "varchar(15) default NULL",
-				"SQLField_Oracle" => "varchar2(15) default NULL",
-				"SQLField_MSSQL" => "VARCHAR(15) NULL"
-		);
-	}
+        return array(
+            "SQLField" => "varchar(15) default NULL",
+            "SQLField_Oracle" => "varchar2(15) default NULL",
+            "SQLField_MSSQL" => "VARCHAR(15) NULL"
+        );
+    }
 	
 	public function getExampleColumnHTML() {
 		$L = Core::$language->getCurrentLanguageStrings();
@@ -43,23 +97,44 @@ EOF;
 		return $html;
 	}
 	
-	public function getRowGenerationOptionsAPI($generator, $json, $numCols) {
-		$options = array(
-				"thousep" => $json->settings->thousep,
-				"upper" => $json->settings->upper
+	public function getRowGenerationOptionsUI($generator, $postdata, $column, $numCols) {
+		return array(
+			"formatCode" => $postdata["dtExample_$column"],
+			"thousep" => isset($postdata["dtThouSep_$column"]) ? true : false,
+			"upper" => isset($postdata["dtUpperDigit_$column"]) ? true : false,
+			"remdash" => isset($postdata["dtRemoveDash_$column"]) ? true : false
 		);
-		return $options;
+    }
+	
+	public function getRowGenerationOptionsAPI($generator, $json, $numCols) {
+		return array(
+			"formatCode" => $json->settings->placeholder,
+			"thousep" => $json->settings->thousep,
+			"upper" => $json->settings->upper,
+			"remdash" => $json->settings->remdash
+		);
 	}
 	
 	public function getOptionsColumnHTML() {
 		$html =<<< END
 <input type="checkbox" name="dtThouSep_%ROW%" id="dtThouSep_%ROW%" />
 	<label for="dtThouSep_%ROW%">{$this->L["thousands_separator"]}</label><br/>
-<input type="checkbox" name="dtUpperDigit%ROW%" id="dtUpperDigit%ROW%" checked="checked" />
-	<label for="dtUpperDigit%ROW%">{$this->L["digit_uppercase"]}</label><br/>
-<input type="checkbox" name="dtRemoveDash%ROW%" id="dtRemoveDash%ROW%" />
-	<label for="dtRemoveDash%ROW%">{$this->L["remove_dash"]}</label>
+<input type="checkbox" name="dtUpperDigit_%ROW%" id="dtUpperDigit_%ROW%" checked="checked" />
+	<label for="dtUpperDigit_%ROW%">{$this->L["digit_uppercase"]}</label><br/>
+<input type="checkbox" name="dtRemoveDash_%ROW%" id="dtRemoveDash_%ROW%" />
+	<label for="dtRemoveDash_%ROW%">{$this->L["remove_dash"]}</label>
 END;
 		return $html;
+	}
+	
+	private function getDigit($rut){
+		$rutA = array_reverse(str_split($rut));
+		
+		for($i = 0, $n = 0; $i<count($rutA); $n += $rutA[$i] * ($i % 6 + 2), $i++);
+		$digit = 11 - $n % 11;
+		
+		if($digit == 10) return "k";
+		if($digit == 11) return "0";
+		return $digit;
 	}
 }

--- a/plugins/dataTypes/Rut/Rut.class.php
+++ b/plugins/dataTypes/Rut/Rut.class.php
@@ -23,55 +23,66 @@ class DataType_Rut extends DataTypePlugin {
 		$options = $generationContextData["generationOptions"];
 		
 		$rowRutInfo = array();
-		while (list($key, $info) = each($generationContextData["existingRowData"])) {
-			if ($info["dataTypeFolder"] == "Rut") {
-				
+		while (list($key, $info) = each($generationContextData["existingRowData"]))
+        {
+			if ($info["dataTypeFolder"] == "Rut")
+            {	
 				$rowRutInfo = $info;
 				break;
 			}
 		}
 		reset($generationContextData["existingRowData"]);
 		
-		/*if (!empty($rowRutInfo)) {
-        
+		if (!empty($rowRutInfo))
+        {
+            $rutn = $info["randomData"]["rut"];
+            $digit = $info["randomData"]["digit"];
 		}
-		else*/ {
+		else
+        {
 			$rutn = sprintf("%d%03d%03d", mt_rand(5, 50), mt_rand(0,999), mt_rand(0,999));
-            
-			$display = "";
+            $digit = $this->getDigit($rutn);
+        }
+
+		$display = "";
 			
-			if( strpos($options["formatCode"], "xxxxxxxx") !== false )
+        if( strpos($options["formatCode"], "xxxxxxxx") !== false )
+        {
+            if( $options["thousep"] )
+            {
+                $display = number_format($rutn, 0, ",", ".");
+            }
+            else
+            {
+                $display = $rutn;
+            }
+        }
+
+        if( strpos($options["formatCode"], "xxxxxxxx-y") !== false )
+        {
+            if( !$options["remdash"] )
+            {
+                $display .= "-";
+            }
+        }
+			
+		if( strpos($options["formatCode"], "y") !== false )
+		{
+			if( $options["upper"] )
 			{
-                    if( $options["thousep"] )
-                    {
-                            $display = number_format($rutn, 0, ",", ".");
-                        }
-                    else {
-                        $display = $rutn;
-                    }
-                }
-			if( strpos($options["formatCode"], "xxxxxxxx-y") !== false )
-			{
-				if( !$options["remdash"] )
-				{
-					$display .= "-";
-				}
+				$display .= strtoupper($digit);
 			}
-			
-			if( strpos($options["formatCode"], "y") !== false )
-			{
-				if( $options["upper"] )
-				{
-					$display .= strtoupper($this->getDigit($rutn));
-				}
-				else {
-					$display .= $this->getDigit($rutn);
-				}
+			else
+            {
+				$display .= $digit;
 			}
 		}
 		
-		return array(
-				"display" => $display
+		return array
+        (
+			"display" => $display,
+            "rut" => $rutn,
+            "digit" => $digit
 		);
     }
 	

--- a/plugins/dataTypes/Rut/Rut.class.php
+++ b/plugins/dataTypes/Rut/Rut.class.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @package DataTypes
+ */
+
+
+class DataType_Rut extends DataTypePlugin {
+	protected $isEnabled = true;
+	protected $dataTypeName = "Rut";
+	protected $dataTypeFieldGroup = "human_data";
+	protected $dataTypeFieldGroupOrder = 105;
+
+	public function __construct($runtimeContext) {
+		parent::__construct($runtimeContext);
+		if ($runtimeContext == "generation") {
+
+		}
+	}
+	
+	public function generate($generator, $generationContextData) {
+	}
+	
+	public function getDataTypeMetadata() {
+		return array(
+				"SQLField" => "varchar(15) default NULL",
+				"SQLField_Oracle" => "varchar2(15) default NULL",
+				"SQLField_MSSQL" => "VARCHAR(15) NULL"
+		);
+	}
+	
+	public function getExampleColumnHTML() {
+		$L = Core::$language->getCurrentLanguageStrings();
+		
+		$html =<<<EOF
+	<select name="dtExample_%ROW%" id="dtExample_%ROW%">
+		<option value="">{$L["please_select"]}</option>
+		<option value="xxxxxxxx-y">12345678-9 ({$this->L["rut_default"]})</option>
+		<option value="xxxxxxxx">12345678 ({$this->L["only_number"]})</option>
+		<option value="y">9 ({$this->L["only_digit"]})</option>
+	</select>
+EOF;
+		return $html;
+	}
+	
+	public function getRowGenerationOptionsAPI($generator, $json, $numCols) {
+		$options = array(
+				"thousep" => $json->settings->thousep,
+				"upper" => $json->settings->upper
+		);
+		return $options;
+	}
+	
+	public function getOptionsColumnHTML() {
+		$html =<<< END
+<input type="checkbox" name="dtThouSep_%ROW%" id="dtThouSep_%ROW%" />
+	<label for="dtThouSep_%ROW%">{$this->L["thousands_separator"]}</label><br/>
+<input type="checkbox" name="dtUpperDigit%ROW%" id="dtUpperDigit%ROW%" checked="checked" />
+	<label for="dtUpperDigit%ROW%">{$this->L["digit_uppercase"]}</label><br/>
+<input type="checkbox" name="dtRemoveDash%ROW%" id="dtRemoveDash%ROW%" />
+	<label for="dtRemoveDash%ROW%">{$this->L["remove_dash"]}</label>
+END;
+		return $html;
+	}
+}

--- a/plugins/dataTypes/Rut/Rut.js
+++ b/plugins/dataTypes/Rut/Rut.js
@@ -31,42 +31,39 @@ define([
 	var _loadRow = function(rowNum, data) {
 		return {
 			execute: function() {},
-			isComplete: function() {
-				if ($("#dtOption_" + rowNum).length) {
-					$("#dtExample_" + rowNum).val(data.formatCode);
-					
-					if ($("#dtThouSep_" + rowNum).length) {
-						if (data.thousep) {
-							$("#dtThouSep_" + rowNum).attr("checked", "checked");
-						} else {
-							$("#dtThouSep_" + rowNum).removeAttr("checked");
-						}
-					}
-					if ($("#dtUpperDigit_" + rowNum).length) {
-						if (data.upper) {
-							$("#dtUpperDigit_" + rowNum).attr("checked", "checked");
-						} else {
-							$("#dtUpperDigit_" + rowNum).removeAttr("checked");
-						}
-					}
-					if ($("#dtRemoveDash_" + rowNum).length) {
-						if (data.remdash) {
-							$("#dtRemoveDash_" + rowNum).attr("checked", "checked");
-						} else {
-							$("#dtRemoveDash_" + rowNum).removeAttr("checked");
-						}
-					}
-					
-				}
-				
-				return true;
+			isComplete: function () {
+			    $("#dtExample_" + rowNum).val(data.example);
+
+			    if ($("#dtThouSep_" + rowNum).length) {
+			        if (data.thousep) {
+			            $("#dtThouSep_" + rowNum).attr("checked", "checked");
+			        } else {
+			            $("#dtThouSep_" + rowNum).removeAttr("checked");
+			        }
+			    }
+			    if ($("#dtUpperDigit_" + rowNum).length) {
+			        if (data.upper) {
+			            $("#dtUpperDigit_" + rowNum).attr("checked", "checked");
+			        } else {
+			            $("#dtUpperDigit_" + rowNum).removeAttr("checked");
+			        }
+			    }
+			    if ($("#dtRemoveDash_" + rowNum).length) {
+			        if (data.remdash) {
+			            $("#dtRemoveDash_" + rowNum).attr("checked", "checked");
+			        } else {
+			            $("#dtRemoveDash_" + rowNum).removeAttr("checked");
+			        }
+			    }
+
+			    return true;
 			}
 		};
 	};
 
 	var _saveRow = function(rowNum) {
 		return {
-			"formatCode":  $("#dtExample_" + rowNum).val(),
+		    "example": $("#dtExample_" + rowNum).val(),
 			"thousep": ($("#dtThouSep_" + rowNum).attr("checked")) ? "checked" : "",
 			"upper": ($("#dtUpperDigit_" + rowNum).attr("checked")) ? "checked" : "",
 			"remdash": ($("#dtRemoveDash_" + rowNum).attr("checked")) ? "checked" : ""

--- a/plugins/dataTypes/Rut/Rut.js
+++ b/plugins/dataTypes/Rut/Rut.js
@@ -1,0 +1,65 @@
+/*global $:false*/
+define([
+	"manager",
+	"constants",
+	"lang",
+	"generator"
+], function(manager, C, L, generator) {
+
+	"use strict";
+
+	var MODULE_ID = "data-type-Rut";
+	var LANG = L.dataTypePlugins.Names;
+
+	var _loadRow = function(rowNum, data) {
+		return {
+			execute: function() {},
+			isComplete: function() {
+				if ($("#dtOption_" + rowNum).length) {
+					$("#dtExample_" + rowNum).val(data.formatCode);
+					
+					if ($("#dtThouSep_" + rowNum).length) {
+						if (data.thousep) {
+							$("#dtThouSep_" + rowNum).attr("checked", "checked");
+						} else {
+							$("#dtThouSep_" + rowNum).removeAttr("checked");
+						}
+					}
+					if ($("#dtUpperDigit_" + rowNum).length) {
+						if (data.upper) {
+							$("#dtUpperDigit_" + rowNum).attr("checked", "checked");
+						} else {
+							$("#dtUpperDigit_" + rowNum).removeAttr("checked");
+						}
+					}
+					if ($("#dtRemoveDash_" + rowNum).length) {
+						if (data.remdash) {
+							$("#dtRemoveDash_" + rowNum).attr("checked", "checked");
+						} else {
+							$("#dtRemoveDash_" + rowNum).removeAttr("checked");
+						}
+					}
+					
+				}
+				
+				return true;
+			}
+		};
+	};
+
+	var _saveRow = function(rowNum) {
+		return {
+			"formatCode":  $("#dtExample_" + rowNum).val(),
+			"thousep": ($("#dtThouSep_" + rowNum).attr("checked")) ? "checked" : "",
+			"upper": ($("#dtUpperDigit_" + rowNum).attr("checked")) ? "checked" : "",
+			"remdash": ($("#dtRemoveDash_" + rowNum).attr("checked")) ? "checked" : ""
+		};
+	};
+
+	// register our module
+	manager.registerDataType(MODULE_ID, {
+		loadRow: _loadRow,
+		saveRow: _saveRow
+	});
+
+});

--- a/plugins/dataTypes/Rut/Rut.js
+++ b/plugins/dataTypes/Rut/Rut.js
@@ -11,6 +11,23 @@ define([
 	var MODULE_ID = "data-type-Rut";
 	var LANG = L.dataTypePlugins.Names;
 
+	var _validate = function (rows) {
+	    var visibleProblemRows = [];
+	    var problemFields = [];
+	    for (var i = 0; i < rows.length; i++) {
+	        if ($("#dtExample_" + rows[i]).val() === "") {
+	            var visibleRowNum = generator.getVisibleRowOrderByRowNum(rows[i]);
+	            visibleProblemRows.push(visibleRowNum);
+	            problemFields.push($("#dtExample_" + rows[i]));
+	        }
+	    }
+	    var errors = [];
+	    if (visibleProblemRows.length) {
+	        errors.push({ els: problemFields, error: LANG.incomplete_fields + " <b>" + visibleProblemRows.join(", ") + "</b>" });
+	    }
+	    return errors;
+	};
+
 	var _loadRow = function(rowNum, data) {
 		return {
 			execute: function() {},
@@ -58,6 +75,7 @@ define([
 
 	// register our module
 	manager.registerDataType(MODULE_ID, {
+	    validate: _validate,
 		loadRow: _loadRow,
 		saveRow: _saveRow
 	});

--- a/plugins/dataTypes/Rut/lang/en.php
+++ b/plugins/dataTypes/Rut/lang/en.php
@@ -1,0 +1,13 @@
+<?php
+
+$L = array();
+$L["DATA_TYPE_NAME"] = "Rut";
+
+$L["different_formats"] = "Different formats";
+$L["rut_default"] = "Default";
+$L["only_number"] = "Only number";
+$L["only_digit"] = "Only verification digit";
+
+$L["thousands_separator"] = "Thousands separator";
+$L["digit_uppercase"] = "Uppercase digit";
+$L["remove_dash"] = "Exclude dash";

--- a/plugins/dataTypes/Rut/lang/en.php
+++ b/plugins/dataTypes/Rut/lang/en.php
@@ -4,6 +4,7 @@ $L = array();
 $L["DATA_TYPE_NAME"] = "Rut";
 
 $L["different_formats"] = "Different formats";
+$L["incomplete_fields"] = "The Rut data type needs to have the example field selected. Please fix the following rows:";
 $L["rut_default"] = "Default";
 $L["only_number"] = "Only number";
 $L["only_digit"] = "Only verification digit";

--- a/plugins/dataTypes/Rut/lang/es.php
+++ b/plugins/dataTypes/Rut/lang/es.php
@@ -4,10 +4,11 @@ $L = array();
 $L["DATA_TYPE_NAME"] = "Rut";
 
 $L["different_formats"] = "Formatos diferentes";
+$L["incomplete_fields"] = "El tipo de dato Rut necesita tener seleccionado el campo ejemplo. Por favor arreglar las siguientes filas: ";
 $L["rut_default"] = "Por defecto";
-$L["only_number"] = "Sólo Rut";
-$L["only_digit"] = "Sólo digito verificador";
+$L["only_number"] = "S&oacute;lo Rut";
+$L["only_digit"] = "S&oacute;lo d&iacute;gito verificador";
 
 $L["thousands_separator"] = "Separador de miles";
-$L["digit_uppercase"] = "Digito en mayúsculas";
-$L["remove_dash"] = "Excluir guión";
+$L["digit_uppercase"] = "D&iacute;gito en may&uacute;sculas";
+$L["remove_dash"] = "Excluir gui&oacute;n";

--- a/plugins/dataTypes/Rut/lang/es.php
+++ b/plugins/dataTypes/Rut/lang/es.php
@@ -1,0 +1,13 @@
+<?php
+
+$L = array();
+$L["DATA_TYPE_NAME"] = "Rut";
+
+$L["different_formats"] = "Formatos diferentes";
+$L["rut_default"] = "Por defecto";
+$L["only_number"] = "Sólo Rut";
+$L["only_digit"] = "Sólo digito verificador";
+
+$L["thousands_separator"] = "Separador de miles";
+$L["digit_uppercase"] = "Digito en mayúsculas";
+$L["remove_dash"] = "Excluir guión";


### PR DESCRIPTION
Added Rut (Chilean Unique Tributary Role) used in identification (like Passport Code). It also known as Unique National Role but is the same for coding purpose. (Source: https://en.wikipedia.org/wiki/Rol_%C3%9Anico_Tributario )

- Created DataType with multiple configurations (common case in most systems)
- Added english and spanish language files only
- Added js to manage client logic (load, save and validation)