### PR TITLE
Make the timeout overrideable to match the comment

### DIFF
--- a/resources/classes/Core.class.php
+++ b/resources/classes/Core.class.php
@@ -207,6 +207,9 @@ class Core {
 			if (isset($pluginSettings)) {
 				self::$pluginSettings = $pluginSettings;
 			}
+			if (isset($timeout)) {
+				self::$timeout = $timeout;
+			}
 			if (isset($apiEnabled)) {
 				self::$apiEnabled = $apiEnabled;
 			}


### PR DESCRIPTION
`Core.class.php` says that $timeout is overrideable. Unfortuntately I had to wait a second 5 minutes to determine that it actually wasn't ;)