### PR TITLE
Support for C# as a Programming Language Export Type

### DIFF
--- a/plugins/dataTypes/Date/Date.class.php
+++ b/plugins/dataTypes/Date/Date.class.php
@@ -12,6 +12,7 @@ class DataType_Date extends DataTypePlugin {
 	protected $dataTypeFieldGroupOrder = 40;
 	protected $jsModules = array("Date.js");
 	private static $useSafeDates = false;
+	private $formatCode;
 
 
 	public function __construct($runtimeContext) {
@@ -48,8 +49,8 @@ class DataType_Date extends DataTypePlugin {
 	public function getRowGenerationOptionsUI($generator, $postdata, $colNum, $numCols) {
 		if (empty($postdata["dtFromDate_$colNum"]) || empty($postdata["dtToDate_$colNum"]) || empty($postdata["dtOption_$colNum"])) {
 			return false;
-		}
-
+		}	
+		$this->formatCode = $postdata["dtOption_$colNum"];
 		$options = array(
 			"formatCode" => $postdata["dtOption_$colNum"],
 			"from"       => $postdata["dtFromDate_$colNum"],
@@ -60,6 +61,7 @@ class DataType_Date extends DataTypePlugin {
 	}
 
 	public function getRowGenerationOptionsAPI($generator, $json, $numCols) {
+		$this->formatCode = $json->settings->placeholder;
 		$options = array(
 			"formatCode" => $json->settings->placeholder,
 			"from"       => $json->settings->fromDate,
@@ -70,6 +72,8 @@ class DataType_Date extends DataTypePlugin {
 
 	public function getDataTypeMetadata() {
 		return array(
+			"type" => "date",
+			"formatCode" => $this->formatCode,
 			"SQLField" => "varchar(255)",
 			"SQLField_Oracle" => "varchar2(255)",
 			"SQLField_MSSQL" => "VARCHAR(255)"

--- a/plugins/exportTypes/ProgrammingLanguage/README.md
+++ b/plugins/exportTypes/ProgrammingLanguage/README.md
@@ -8,6 +8,7 @@ There's only a single setting: `language`, which should be a string containing o
 - `Perl`
 - `JavaScript` (note that this and the other options are case-sensitive!)
 - `Ruby`
+- `CSharp`
 
 ### Example API Usage
 

--- a/plugins/exportTypes/ProgrammingLanguage/schema.json
+++ b/plugins/exportTypes/ProgrammingLanguage/schema.json
@@ -4,7 +4,7 @@
 	"type": "object",
 	"properties": {
 		"language": {
-			"enum": ["JavaScript", "Perl", "PHP", "Ruby"]
+			"enum": ["JavaScript", "Perl", "PHP", "Ruby", "CSharp"]
 		}
 	},
 	"required": ["language"]


### PR DESCRIPTION
I added support for C# as a Programming Language by using Anonymous Types.

Apart from modifying the export plugin I also modified the DataType `Date`, to add the `formatCode` to its metadata, in order to parse the dates to a `DateTime` type for C#.