### PR TITLE
Fixed instances of short region where region code used was greater than 3 characters

### DIFF
--- a/plugins/countries/Austria/Austria.class.php
+++ b/plugins/countries/Austria/Austria.class.php
@@ -17,7 +17,7 @@ class Country_Austria extends CountryPlugin {
 	protected $countryData = array(
 		array(
 			"regionName" => "Vienna",
-			"regionShort" => "Wien",
+			"regionShort" => "Wie",
 			"regionSlug" => "vienna",
 			"weight" => 4113,
 			"cities" => array(
@@ -26,7 +26,7 @@ class Country_Austria extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Vorarlberg",
-			"regionShort" => "Vbg.",
+			"regionShort" => "Vbg",
 			"regionSlug" => "voralberg",
 			"weight" => 142,
 			"cities" => array(
@@ -59,7 +59,7 @@ class Country_Austria extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Salzburg",
-			"regionShort" => "Sbg.",
+			"regionShort" => "Sbg",
 			"regionSlug" => "salzburg",
 			"weight" => 74,
 			"cities" => array(
@@ -69,7 +69,7 @@ class Country_Austria extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Styria",
-			"regionShort" => "Stm.",
+			"regionShort" => "Stm",
 			"regionSlug" => "styria",
 			"weight" => 73,
 			"cities" => array(
@@ -79,7 +79,7 @@ class Country_Austria extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Burgenland",
-			"regionShort" => "Bgl.",
+			"regionShort" => "Bgl",
 			"regionSlug" => "burgenland",
 			"weight" => 72,
 			"cities" => array(
@@ -91,7 +91,7 @@ class Country_Austria extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Carinthia",
-			"regionShort" => "Ktn.",
+			"regionShort" => "Ktn",
 			"regionSlug" => "carinthia",
 			"weight" => 59,
 			"cities" => array(
@@ -102,7 +102,7 @@ class Country_Austria extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Tyrol",
-			"regionShort" => "Tirol",
+			"regionShort" => "Tir",
 			"regionSlug" => "tyrol",
 			"weight" => 56,
 			"cities" => array(

--- a/plugins/countries/Chile/Chile.class.php
+++ b/plugins/countries/Chile/Chile.class.php
@@ -229,7 +229,7 @@ class Country_Chile extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Biobío",
-			"regionShort" => "VII",
+			"regionShort" => "8",
 			"regionSlug" => "biobio",
 			"weight" => 1179,
 			"cities" => array(

--- a/plugins/countries/Turkey/Turkey.class.php
+++ b/plugins/countries/Turkey/Turkey.class.php
@@ -29,7 +29,7 @@ class Country_Turkey extends CountryPlugin {
 	protected $countryData = array(
 		array(
 			"regionName" => "Istanbul",
-			"regionShort" => "Istanbul",
+			"regionShort" => "Ist",
 			"regionSlug" => "istanbul",
 			"weight" => 14,
 			"cities" => array(
@@ -38,7 +38,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Ankara",
-			"regionShort" => "Ankara",
+			"regionShort" => "Ank",
 			"regionSlug" => "ankara",
 			"weight" => 5,
 			"cities" => array(
@@ -47,7 +47,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "İzmir",
-			"regionShort" => "İzmir",
+			"regionShort" => "İzm",
 			"regionSlug" => "izmir",
 			"weight" => 4,
 			"cities" => array(
@@ -56,7 +56,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Bursa",
-			"regionShort" => "Bursa",
+			"regionShort" => "Bur",
 			"regionSlug" => "bursa",
 			"weight" => 3,
 			"cities" => array(
@@ -65,7 +65,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Antalya",
-			"regionShort" => "Antalya",
+			"regionShort" => "Ant",
 			"regionSlug" => "antalya",
 			"weight" => 2,
 			"cities" => array(
@@ -74,7 +74,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Adana",
-			"regionShort" => "Adana",
+			"regionShort" => "Ada",
 			"regionSlug" => "adana",
 			"weight" => 2,
 			"cities" => array(
@@ -83,7 +83,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Konya",
-			"regionShort" => "Konya",
+			"regionShort" => "Kon",
 			"regionSlug" => "konya",
 			"weight" => 2,
 			"cities" => array(
@@ -92,7 +92,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Gaziantep",
-			"regionShort" => "Gaziantep",
+			"regionShort" => "Gaz",
 			"regionSlug" => "gaziantep",
 			"weight" => 2,
 			"cities" => array(
@@ -101,7 +101,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Şanlıurfa",
-			"regionShort" => "Şanlıurfa",
+			"regionShort" => "Şan",
 			"regionSlug" => "sanliurfa",
 			"weight" => 2,
 			"cities" => array(
@@ -110,7 +110,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Mersin",
-			"regionShort" => "Mersin",
+			"regionShort" => "Mer",
 			"regionSlug" => "mersin",
 			"weight" => 2,
 			"cities" => array(
@@ -119,7 +119,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Kocaeli",
-			"regionShort" => "Kocaeli",
+			"regionShort" => "Koc",
 			"regionSlug" => "kocaeli",
 			"weight" => 2,
 			"cities" => array(
@@ -128,7 +128,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Diyarbakır",
-			"regionShort" => "Diyarbakır",
+			"regionShort" => "Diy",
 			"regionSlug" => "diyarbakir",
 			"weight" => 2,
 			"cities" => array(
@@ -137,7 +137,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Hatay",
-			"regionShort" => "Hatay",
+			"regionShort" => "Hat",
 			"regionSlug" => "hatay",
 			"weight" => 2,
 			"cities" => array(
@@ -146,7 +146,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Manisa",
-			"regionShort" => "Manisa",
+			"regionShort" => "Man",
 			"regionSlug" => "manisa",
 			"weight" => 1,
 			"cities" => array(
@@ -155,7 +155,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Kayseri",
-			"regionShort" => "Kayseri",
+			"regionShort" => "Kay",
 			"regionSlug" => "kayseri",
 			"weight" => 1,
 			"cities" => array(
@@ -164,7 +164,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Samsun",
-			"regionShort" => "Samsun",
+			"regionShort" => "Sam",
 			"regionSlug" => "samsun",
 			"weight" => 1,
 			"cities" => array(
@@ -173,7 +173,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Balıkesir",
-			"regionShort" => "Balıkesir",
+			"regionShort" => "Bal",
 			"regionSlug" => "balikesir",
 			"weight" => 1,
 			"cities" => array(
@@ -182,7 +182,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Kahramanmaraş",
-			"regionShort" => "Kahramanmaraş",
+			"regionShort" => "Kah",
 			"regionSlug" => "kahramanmaras",
 			"weight" => 1,
 			"cities" => array(
@@ -200,7 +200,7 @@ class Country_Turkey extends CountryPlugin {
 		),
 		array(
 			"regionName" => "Aydın",
-			"regionShort" => "Aydın",
+			"regionShort" => "Ayd",
 			"regionSlug" => "aydin",
 			"weight" => 1,
 			"cities" => array(


### PR DESCRIPTION
I've changed all instances of regionShort that were > 3 characters to 3 characters.

One concern is the change in Chili - Chili uses roman numerals for region short. VIII (8) is larger than 3 chars, so I have changed it to the number 8.

For consistency, should I go ahead and change all region shorts in Chile to be base 10 numbers, or is there a particular reason behind the roman numerals?

Thanks,
Mansoor