### PR TITLE
Make "date to" inclusive of last selected day

### DIFF
--- a/plugins/dataTypes/Date/Date.class.php
+++ b/plugins/dataTypes/Date/Date.class.php
@@ -325,7 +325,7 @@ END;
 		list($month, $day, $year) = explode("/", $options["from"]);
 		$fromDate = mktime(0, 0, 0, $month, $day, $year);
 		list($month, $day, $year) = explode("/", $options["to"]);
-		$toDate = mktime(0, 0, 0, $month, $day, $year);
+		$toDate = mktime(23, 59, 59, $month, $day, $year);
 
 		// randomly pick a date between those dates
 		$randDate = mt_rand($fromDate, $toDate);


### PR DESCRIPTION
Make behaviour for dates consistent with integers etc in that the script should allow dates 'within' the last selected day. Currently it is exclusive of the last selected day because it assumes midnight on (i.e. at the start of) that day as the highest possible value.