### PR TITLE
Add support for specifying character lengths in API requests.

### DIFF
--- a/plugins/dataTypes/TextRandom/TextRandom.class.php
+++ b/plugins/dataTypes/TextRandom/TextRandom.class.php
@@ -21,7 +21,7 @@ class DataType_TextRandom extends DataTypePlugin {
 
 	public function generate($generator, $generationContextData) {
 		$options = $generationContextData["generationOptions"];
-		$textStr = Utils::generateRandomTextStr($this->words, $options["startsWithLipsum"], "range", $options["numWordsMin"], $options["numWordsMax"]);
+		$textStr = Utils::generateRandomTextStr($this->words, $options["startsWithLipsum"], "range", $options["numWordsMin"], $options["numWordsMax"], $options['maxChars']);
 		return array(
 			"display" => $textStr
 		);
@@ -43,7 +43,8 @@ class DataType_TextRandom extends DataTypePlugin {
 		$options = array(
 			"numWordsMin"      => $postdata["dtNumWordsMin_$column"],
 			"numWordsMax"      => $postdata["dtNumWordsMax_$column"],
-			"startsWithLipsum" => isset($postdata["dtStartsWithLipsum_$column"]) ? true : false
+			"startsWithLipsum" => isset($postdata["dtStartsWithLipsum_$column"]) ? true : false,
+                        "maxChars"         => $postdata["maxChars"]
 		);
 
 		return $options;
@@ -53,7 +54,8 @@ class DataType_TextRandom extends DataTypePlugin {
 		$options = array(
 			"numWordsMin"      => $json->settings->minWords,
 			"numWordsMax"      => $json->settings->maxWords,
-			"startsWithLipsum" => $json->settings->startsWithLipsum
+			"startsWithLipsum" => $json->settings->startsWithLipsum,
+                        "maxChars"         => $json->settings->maxChars
 		);
 		return $options;
 	}
@@ -68,6 +70,7 @@ class DataType_TextRandom extends DataTypePlugin {
 			{$this->L["generate"]} #<input type="text" name="dtNumWordsMin_%ROW%" id="dtNumWordsMin_%ROW%" style="width: 40px" value="1" />
 			{$this->L["to"]} #<input type="text" name="dtNumWordsMax_%ROW%" id="dtNumWordsMax_%ROW%" style="width: 40px" value="10" /> 
 			{$this->L["words"]}
+			{$this->L["maxChars"]} up to <input type="text" name="dtmaxChars_%ROW%" id="dtmaxChars_%ROW%" style="width: 40px" value="50" /> max chars
 		</div>
 END;
 		return $html;

--- a/plugins/dataTypes/TextRandom/TextRandom.js
+++ b/plugins/dataTypes/TextRandom/TextRandom.js
@@ -22,7 +22,8 @@ define([
 		return {
 			startsWithLipsum: $("#dtStartsWithLipsum_" + rowNum).attr("checked") ? 1 : 0,
 			minWords: $("#dtNumWordsMin_" + rowNum).val(),
-			maxWords: $("#dtNumWordsMax_" + rowNum).val()
+			maxWords: $("#dtNumWordsMax_" + rowNum).val(),
+			maxChars: $("#dtmaxChars_" + rowNum).val()
 		};
 	};
 
@@ -38,6 +39,7 @@ define([
 					}
 					$("#dtNumWordsMin_" + rowNum).val(data.minWords);
 					$("#dtNumWordsMax_" + rowNum).val(data.maxWords);
+					$("#dtmaxChars_" + rowNum).val(data.maxChars);
 					return true;
 				}
 				return false;

--- a/resources/classes/Utils.class.php
+++ b/resources/classes/Utils.class.php
@@ -294,7 +294,7 @@ class Utils {
 	 * @param integer $min     - the minimum # of words to return OR the total number
 	 * @param integer $max     - the max # of words to return (or null for "fixed" type)
 	 */
-	public static function generateRandomTextStr($words, $startsWithLipsum, $type, $min, $max = "") {
+	public static function generateRandomTextStr($words, $startsWithLipsum, $type, $min, $max = "", $maxChars = 0) {
 
 		// determine the number of words to return
 		if ($type == "fixed") {
@@ -315,7 +315,15 @@ class Utils {
 		}
 		$wordArray = array_slice($words, $offset, $numWords);
 
-		return join(" ", $wordArray);
+//		return join(" ", $wordArray);
+		$return_str = join(" ", $wordArray);
+                if ( $maxChars > 0 ) {
+                    error_log( "maxChars: $maxChars" );
+                    $return_str = substr( $return_str, 0, $maxChars );
+                } else {
+                    error_log( "No maxChars" );
+                }
+                return $return_str;
 	}
 
 


### PR DESCRIPTION
NOTE!!! I've made an attempt to patch the UI code to also support
NOTE!!! specifying character lenghts, but I'm *not* a UI dev, and
NOTE!!! this does *not* work.

---

This patch make it possible for me to use generatedata to create mock data for databases that have column length limits ( ie pretty much all of them ).