### PR TITLE
fix field length for SocialSecurityNumber

### DIFF
--- a/plugins/dataTypes/SocialSecurityNumber/SocialSecurityNumber.class.php
+++ b/plugins/dataTypes/SocialSecurityNumber/SocialSecurityNumber.class.php
@@ -31,9 +31,9 @@ class DataType_SocialSecurityNumber extends DataTypePlugin {
 
 	public function getDataTypeMetadata() {
 		return array(
-			"SQLField" => "varchar(9) default NULL",
-			"SQLField_Oracle" => "varchar2(9) default NULL",
-			"SQLField_MSSQL" => "VARCHAR(9) NULL"
+			"SQLField" => "varchar(11) default NULL",
+			"SQLField_Oracle" => "varchar2(11) default NULL",
+			"SQLField_MSSQL" => "VARCHAR(11) NULL"
 		);
 	}
 


### PR DESCRIPTION
the SSN creates strings with 11 chars, so the field lengths for sql exports need to match this